### PR TITLE
efactor(13): 최신순 정렬 목록 조회 시 offset -> cursor 페이지네이션 전환

### DIFF
--- a/src/main/java/io/mipangg/querymarket/domain/common/CursorPageResponse.java
+++ b/src/main/java/io/mipangg/querymarket/domain/common/CursorPageResponse.java
@@ -1,0 +1,18 @@
+package io.mipangg.querymarket.domain.common;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CursorPageResponse<T> implements ProductPageResponse {
+
+    private List<T> content;        // 현재 페이지 데이터 목록
+    private Long nextCursor;     // 다음 커서
+    private boolean hasNext;        // 다음 페이지 존재 여부
+
+}

--- a/src/main/java/io/mipangg/querymarket/domain/common/PageResponse.java
+++ b/src/main/java/io/mipangg/querymarket/domain/common/PageResponse.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Page;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PageResponse<T> {
+public class PageResponse<T> implements ProductPageResponse {
     private List<T> content;        // 현재 페이지 데이터 목록
     private int page;        // 조회할 페이지 번호 (0부터 시작)
     private int size;           // 한 페이지당 조회할 데이터 개수

--- a/src/main/java/io/mipangg/querymarket/domain/common/ProductPageResponse.java
+++ b/src/main/java/io/mipangg/querymarket/domain/common/ProductPageResponse.java
@@ -1,0 +1,8 @@
+package io.mipangg.querymarket.domain.common;
+
+
+import java.util.List;
+
+public interface ProductPageResponse<T> {
+
+}

--- a/src/main/java/io/mipangg/querymarket/domain/product/controller/ProductController.java
+++ b/src/main/java/io/mipangg/querymarket/domain/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package io.mipangg.querymarket.domain.product.controller;
 
-import io.mipangg.querymarket.domain.common.PageResponse;
+import io.mipangg.querymarket.domain.common.CursorPageResponse;
+import io.mipangg.querymarket.domain.common.ProductPageResponse;
 import io.mipangg.querymarket.domain.product.dto.ProductCreateRequest;
 import io.mipangg.querymarket.domain.product.dto.ProductDetailResponse;
 import io.mipangg.querymarket.domain.product.dto.ProductListRequest;
@@ -60,7 +61,7 @@ public class ProductController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public PageResponse<ProductSummaryResponse> getProducts(
+    public ProductPageResponse getProducts(
             @Valid ProductListRequest req
         ) {
 
@@ -76,7 +77,7 @@ public class ProductController {
 
     @GetMapping("/search")
     @ResponseStatus(HttpStatus.OK)
-    public PageResponse<ProductSummaryResponse> searchProducts(
+    public ProductPageResponse searchProducts(
             @Valid ProductSearchRequest req
     ) {
         return productService.searchProducts(req);

--- a/src/main/java/io/mipangg/querymarket/domain/product/dto/ProductListRequest.java
+++ b/src/main/java/io/mipangg/querymarket/domain/product/dto/ProductListRequest.java
@@ -1,14 +1,19 @@
 package io.mipangg.querymarket.domain.product.dto;
 
 import io.mipangg.querymarket.domain.product.entity.Category;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 
 public record ProductListRequest(
 
+        @Nullable
+        Long cursor,
+
         @Min(0)
-        @Max(10000)
+        @Max(100)
+        @Nullable
         Integer page,
 
         @Min(0)
@@ -23,10 +28,6 @@ public record ProductListRequest(
 ) {
 
     public ProductListRequest {
-        if (page == null) {
-            page = 0;
-        }
-
         if (size == null) {
             size = 20;
         }

--- a/src/main/java/io/mipangg/querymarket/domain/product/dto/ProductListRequest.java
+++ b/src/main/java/io/mipangg/querymarket/domain/product/dto/ProductListRequest.java
@@ -1,6 +1,7 @@
 package io.mipangg.querymarket.domain.product.dto;
 
 import io.mipangg.querymarket.domain.product.entity.Category;
+import io.mipangg.querymarket.global.validation.PaginationValidator;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -12,8 +13,6 @@ public record ProductListRequest(
         Long cursor,
 
         @Min(0)
-        @Max(100)
-        @Nullable
         Integer page,
 
         @Min(0)
@@ -28,13 +27,23 @@ public record ProductListRequest(
 ) {
 
     public ProductListRequest {
+        if (page == null) {
+            page = 0;
+        }
+
         if (size == null) {
             size = 20;
         }
 
         if (sort == null || sort.isBlank()) {
-            sort = "latest";
+            if (cursor != null) {
+                sort = "latest";
+            } else {
+                sort = "views";
+            }
         }
+
+        PaginationValidator.validatePaginationStrategy(sort, cursor);
     }
 
 }

--- a/src/main/java/io/mipangg/querymarket/domain/product/dto/ProductListRequest.java
+++ b/src/main/java/io/mipangg/querymarket/domain/product/dto/ProductListRequest.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.Pattern;
 public record ProductListRequest(
 
         @Min(0)
-        @Max(100)
+        @Max(10000)
         Integer page,
 
         @Min(0)
@@ -28,7 +28,7 @@ public record ProductListRequest(
         }
 
         if (size == null) {
-            size = 10;
+            size = 20;
         }
 
         if (sort == null || sort.isBlank()) {

--- a/src/main/java/io/mipangg/querymarket/domain/product/dto/ProductSearchRequest.java
+++ b/src/main/java/io/mipangg/querymarket/domain/product/dto/ProductSearchRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Pattern;
 
 public record ProductSearchRequest(
         @Min(0)
-        @Max(100)
+        @Max(10000)
         Integer page,
 
         @Min(0)
@@ -27,7 +27,7 @@ public record ProductSearchRequest(
         }
 
         if (size == null) {
-            size = 10;
+            size = 20;
         }
 
         if (sort == null || sort.isBlank()) {

--- a/src/main/java/io/mipangg/querymarket/domain/product/dto/ProductSearchRequest.java
+++ b/src/main/java/io/mipangg/querymarket/domain/product/dto/ProductSearchRequest.java
@@ -1,5 +1,8 @@
 package io.mipangg.querymarket.domain.product.dto;
 
+import io.mipangg.querymarket.global.exception.CustomLogicException;
+import io.mipangg.querymarket.global.exception.ErrorCode;
+import io.mipangg.querymarket.global.validation.PaginationValidator;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -12,8 +15,6 @@ public record ProductSearchRequest(
         Long cursor,
 
         @Min(0)
-        @Max(100)
-        @Nullable
         Integer page,
 
         @Min(0)
@@ -29,13 +30,23 @@ public record ProductSearchRequest(
 ) {
 
     public ProductSearchRequest {
+        if (page == null) {
+            page = 0;
+        }
+
         if (size == null) {
             size = 20;
         }
 
         if (sort == null || sort.isBlank()) {
-            sort = "latest";
+            if (cursor == null) {
+                sort = "views";
+            } else {
+                sort = "latest";
+            }
         }
+
+        PaginationValidator.validatePaginationStrategy(sort, cursor);
     }
 
 }

--- a/src/main/java/io/mipangg/querymarket/domain/product/dto/ProductSearchRequest.java
+++ b/src/main/java/io/mipangg/querymarket/domain/product/dto/ProductSearchRequest.java
@@ -1,13 +1,19 @@
 package io.mipangg.querymarket.domain.product.dto;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record ProductSearchRequest(
+
+        @Nullable
+        Long cursor,
+
         @Min(0)
-        @Max(10000)
+        @Max(100)
+        @Nullable
         Integer page,
 
         @Min(0)
@@ -19,13 +25,10 @@ public record ProductSearchRequest(
 
         @NotBlank
         String keyword
+
 ) {
 
     public ProductSearchRequest {
-        if (page == null) {
-            page = 0;
-        }
-
         if (size == null) {
             size = 20;
         }

--- a/src/main/java/io/mipangg/querymarket/domain/product/entity/Product.java
+++ b/src/main/java/io/mipangg/querymarket/domain/product/entity/Product.java
@@ -44,7 +44,6 @@ public class Product {
     @Column(nullable = false)
     private Long viewCount;
 
-    @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -54,12 +53,20 @@ public class Product {
 
 
     @Builder
-    public Product(String name, BigDecimal price, Category category, Seller seller) {
+    public Product(
+            String name,
+            BigDecimal price,
+            Category category,
+            Seller seller,
+            Long viewCount,
+            LocalDateTime createdAt
+    ) {
         this.name = name;
         this.price = price;
         this.category = category;
         this.seller = seller;
-        this.viewCount = 0L;
+        this.viewCount = (viewCount == null) ? 0L : viewCount;
+        this.createdAt = (createdAt == null) ? LocalDateTime.now() : createdAt;
     }
 
     public void updateViewCount() {

--- a/src/main/java/io/mipangg/querymarket/domain/product/repository/ProductRepository.java
+++ b/src/main/java/io/mipangg/querymarket/domain/product/repository/ProductRepository.java
@@ -27,6 +27,21 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             Pageable pageable
     );
 
+    @Query("""
+              select new io.mipangg.querymarket.domain.product.dto.ProductSummaryResponse(
+                  p.id, p.name, p.price, p.category
+              )
+              from Product p
+              where (:category is null or p.category = :category)
+              and (:cursor is null or p.id < :cursor)
+              order by p.id desc
+            """)
+    List<ProductSummaryResponse> findProductsByCursor(
+            @Param("category") Category category,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
     @Query("select p from Product p join fetch p.seller order by p.viewCount desc")
     List<Product> findPopularProducts(Pageable pageable);
 
@@ -39,6 +54,21 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             """)
     Page<ProductSummaryResponse> searchProductsByKeyword(
             @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    @Query("""
+              select new io.mipangg.querymarket.domain.product.dto.ProductSummaryResponse(
+                  p.id, p.name, p.price, p.category
+                  )
+                  from Product p
+                  where (lower(p.name) like lower(concat('%', :keyword, '%')))
+                  and (:cursor is null or p.id < :cursor)
+                  order by p.id desc
+            """)
+    List<ProductSummaryResponse> searchProductsByKeywordWithCursor(
+            @Param("keyword") String keyword,
+            @Param("cursor") Long cursor,
             Pageable pageable
     );
 }

--- a/src/main/java/io/mipangg/querymarket/domain/product/service/ProductService.java
+++ b/src/main/java/io/mipangg/querymarket/domain/product/service/ProductService.java
@@ -1,6 +1,8 @@
 package io.mipangg.querymarket.domain.product.service;
 
+import io.mipangg.querymarket.domain.common.CursorPageResponse;
 import io.mipangg.querymarket.domain.common.PageResponse;
+import io.mipangg.querymarket.domain.common.ProductPageResponse;
 import io.mipangg.querymarket.domain.product.dto.ProductCreateRequest;
 import io.mipangg.querymarket.domain.product.dto.ProductDetailResponse;
 import io.mipangg.querymarket.domain.product.dto.ProductListRequest;
@@ -76,13 +78,13 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponse<ProductSummaryResponse> getProducts(ProductListRequest req) {
-        Pageable pageable = createPageable(req.page(), req.size(), req.sort());
+    public ProductPageResponse getProducts(ProductListRequest req) {
 
-        Page<ProductSummaryResponse> productSummaryResponsePage =
-                productRepository.findProducts(req.category(), pageable);
+        if (req.sort().equals("latest")) {
+            return getProductsByCursor(req);
+        }
 
-        return new PageResponse<>(productSummaryResponsePage);
+        return getProductsByOffset(req);
     }
 
     @Transactional(readOnly = true)
@@ -105,23 +107,89 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponse<ProductSummaryResponse> searchProducts(ProductSearchRequest req) {
+    public ProductPageResponse searchProducts(ProductSearchRequest req) {
+        if (req.sort().equals("latest")) {
+            return searchProductsByCursor(req);
+        }
 
-        Pageable pageable = createPageable(req.page(), req.size(), req.sort());
-
-        Page<ProductSummaryResponse> productSummaryResponsePage =
-                productRepository.searchProductsByKeyword(req.keyword().trim(), pageable);
-
-        return new PageResponse<>(productSummaryResponsePage);
+        return searchProductsByOffset(req);
     }
 
-    private Pageable createPageable(int page, int size, String sort) {
-        if (sort.equals("latest")) {
-            return PageRequest.of(page, size, Sort.by("createdAt").descending());
-        } else if (sort.equals("price")) {
+    private Pageable createPageable(Integer page, Integer size, String sort) {
+        if (sort.equals("price")) {
             return PageRequest.of(page, size, Sort.by("price").ascending());
         } else { // views
             return PageRequest.of(page, size, Sort.by("viewCount").descending());
         }
+    }
+
+
+    private PageResponse getProductsByOffset (ProductListRequest req) {
+        Pageable pageable = createPageable(req.page(), req.size(), req.sort());
+
+        Page<ProductSummaryResponse> products =
+                productRepository.findProducts(req.category(), pageable);
+
+        return new PageResponse<>(products);
+
+    }
+
+    private CursorPageResponse getProductsByCursor(ProductListRequest req) {
+        Pageable pageable = PageRequest.of(0, req.size() + 1);
+
+        List<ProductSummaryResponse> products =
+                productRepository.findProductsByCursor(
+                        req.category(),
+                        req.cursor(),
+                        pageable
+                );
+
+        boolean hasNext = products.size() > req.size();
+
+        if (hasNext) {
+            products.remove(req.size());
+        }
+
+        Long nextCursor = null;
+
+        if (!products.isEmpty()) {
+            nextCursor = products.get(products.size() - 1).id();
+        }
+
+        return new CursorPageResponse<>(products, nextCursor, hasNext);
+    }
+
+    private CursorPageResponse searchProductsByCursor(ProductSearchRequest req) {
+        Pageable pageable = PageRequest.of(0, req.size() + 1);
+
+        List<ProductSummaryResponse> products =
+                productRepository.searchProductsByKeywordWithCursor(
+                        req.keyword().trim(),
+                        req.cursor(),
+                        pageable
+                );
+
+        boolean hasNext = products.size() > req.size();
+
+        if (hasNext) {
+            products.remove(req.size());
+        }
+
+        Long nextCursor = null;
+
+        if (!products.isEmpty()) {
+            nextCursor = products.get(products.size() - 1).id();
+        }
+
+        return new CursorPageResponse<>(products, nextCursor, hasNext);
+    }
+
+    private PageResponse searchProductsByOffset(ProductSearchRequest req) {
+        Pageable pageable = createPageable(req.page(), req.size(), req.sort());
+
+        Page<ProductSummaryResponse> products =
+                productRepository.searchProductsByKeyword(req.keyword(), pageable);
+
+        return new PageResponse<>(products);
     }
 }

--- a/src/main/java/io/mipangg/querymarket/global/init/ProductDummyDataInitializer.java
+++ b/src/main/java/io/mipangg/querymarket/global/init/ProductDummyDataInitializer.java
@@ -1,0 +1,126 @@
+package io.mipangg.querymarket.global.init;
+
+import io.mipangg.querymarket.domain.product.entity.Category;
+import io.mipangg.querymarket.domain.product.entity.Product;
+import io.mipangg.querymarket.domain.seller.entity.Seller;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ProductDummyDataInitializer implements ApplicationRunner {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+
+        int batchSize = 1000;
+
+        List<Seller> sellers = new ArrayList<>();
+
+        // Seller 100명 생성
+        for (int i = 0; i < 100; i++) {
+
+            Seller seller = Seller.builder()
+                    .email(genSellerEmail(i))
+                    .build();
+
+            em.persist(seller);
+
+            sellers.add(seller);
+        }
+
+        em.flush();
+        em.clear();
+
+        // Product 10만 개 생성
+        for (int i = 1; i <= 100000; i++) {
+
+            Seller randomSeller = sellers.get(
+                    ThreadLocalRandom.current()
+                            .nextInt(sellers.size())
+            );
+
+            Product product = Product.builder()
+                    .name(genRandomProductName(i))
+                    .price(
+                            BigDecimal.valueOf(
+                                    ThreadLocalRandom.current()
+                                            .nextInt(1000, 100000)
+                            )
+                    )
+                    .seller(randomSeller)
+                    .category(genRandomCategory())
+                    .viewCount(
+                            ThreadLocalRandom.current()
+                                    .nextLong(0, 100000)
+                    )
+                    .createdAt(
+                            LocalDateTime.now()
+                                    .minusDays(
+                                            ThreadLocalRandom.current()
+                                                    .nextInt(0, 365)
+                                    )
+                    )
+                    .build();
+
+            em.persist(product);
+
+            if (i % batchSize == 0) {
+
+                em.flush();
+                em.clear();
+
+                System.out.println(i + "개 저장 완료");
+            }
+        }
+    }
+
+    private String genSellerEmail(int i) {
+
+        return "seller" + i + "@example.com";
+    }
+
+    private Category genRandomCategory() {
+
+        Category[] values = Category.values();
+
+        return values[
+                ThreadLocalRandom.current()
+                        .nextInt(values.length)
+                ];
+    }
+
+    private String genRandomProductName(int i) {
+
+        String[] keywords = {
+                "맥북",
+                "커피",
+                "원두",
+                "텀블러",
+                "키보드",
+                "마우스",
+                "모니터"
+        };
+
+        String keyword = keywords[
+                ThreadLocalRandom.current()
+                        .nextInt(keywords.length)
+                ];
+
+        return keyword + " 상품 " + i;
+    }
+}

--- a/src/main/java/io/mipangg/querymarket/global/validation/PaginationValidator.java
+++ b/src/main/java/io/mipangg/querymarket/global/validation/PaginationValidator.java
@@ -1,0 +1,16 @@
+package io.mipangg.querymarket.global.validation;
+
+import io.mipangg.querymarket.global.exception.CustomLogicException;
+import io.mipangg.querymarket.global.exception.ErrorCode;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class PaginationValidator {
+
+    public void validatePaginationStrategy(String sort, Long cursor) {
+        if (cursor != null && !sort.equals("latest")) {
+            throw new CustomLogicException(ErrorCode.BAD_REQUEST);
+        }
+    }
+
+}

--- a/src/test/java/io/mipangg/querymarket/TestUtils.java
+++ b/src/test/java/io/mipangg/querymarket/TestUtils.java
@@ -1,6 +1,5 @@
 package io.mipangg.querymarket;
 
-import io.mipangg.querymarket.domain.product.dto.ProductDetailResponse;
 import io.mipangg.querymarket.domain.product.dto.ProductSummaryResponse;
 import io.mipangg.querymarket.domain.product.entity.Category;
 import io.mipangg.querymarket.domain.product.entity.Product;

--- a/src/test/java/io/mipangg/querymarket/domain/controller/ProductControllerTests.java
+++ b/src/test/java/io/mipangg/querymarket/domain/controller/ProductControllerTests.java
@@ -14,7 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.mipangg.querymarket.domain.common.PageResponse;
+import io.mipangg.querymarket.domain.common.CursorPageResponse;
 import io.mipangg.querymarket.domain.product.dto.ProductDetailResponse;
 import io.mipangg.querymarket.domain.product.dto.ProductListRequest;
 import io.mipangg.querymarket.domain.product.dto.ProductSummaryResponse;
@@ -28,9 +28,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -119,8 +116,8 @@ class ProductControllerTests {
     void readProductsSuccessTest() throws Exception {
 
         List<ProductSummaryResponse> content = genProductSummaryResponses();
-        Page<ProductSummaryResponse> page = new PageImpl<>(content, PageRequest.of(0, 20), 5);
-        PageResponse<ProductSummaryResponse> resp = new PageResponse<>(page);
+        CursorPageResponse<ProductSummaryResponse> resp =
+                new CursorPageResponse<>(content, null, false);
 
         when(productService.getProducts(any(ProductListRequest.class))).thenReturn(resp);
 
@@ -135,9 +132,6 @@ class ProductControllerTests {
                 .andExpect(jsonPath("$.content[1].name").value("수영복"))
                 .andExpect(jsonPath("$.content[1].price").value("35000"))
                 .andExpect(jsonPath("$.content[1].category").value("FASHION"))
-                .andExpect(jsonPath("$.page").value(0))
-                .andExpect(jsonPath("$.size").value(20))
-                .andExpect(jsonPath("$.totalElements").value(5))
                 .andExpect(jsonPath("$.hasNext").value(false))
                 .andDo(print());
 
@@ -172,8 +166,8 @@ class ProductControllerTests {
                         Category.FOOD
                 )
         );
-        Page<ProductSummaryResponse> page = new PageImpl<>(content, PageRequest.of(0, 20), 5);
-        PageResponse<ProductSummaryResponse> resp = new PageResponse<>(page);
+        CursorPageResponse<ProductSummaryResponse> resp =
+                new CursorPageResponse<>(content, null, false);
 
         when(productService.getProducts(any(ProductListRequest.class))).thenReturn(resp);
 
@@ -186,9 +180,6 @@ class ProductControllerTests {
                 .andExpect(jsonPath("$.content[0].name").value("단팥빵"))
                 .andExpect(jsonPath("$.content[0].price").value("4200"))
                 .andExpect(jsonPath("$.content[0].category").value("FOOD"))
-                .andExpect(jsonPath("$.page").value(0))
-                .andExpect(jsonPath("$.size").value(20))
-                .andExpect(jsonPath("$.totalElements").value(1))
                 .andExpect(jsonPath("$.hasNext").value(false))
                 .andDo(print());
 

--- a/src/test/java/io/mipangg/querymarket/domain/product/ProductServiceTests.java
+++ b/src/test/java/io/mipangg/querymarket/domain/product/ProductServiceTests.java
@@ -8,9 +8,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.mipangg.querymarket.domain.common.CursorPageResponse;
 import io.mipangg.querymarket.domain.common.PageResponse;
 import io.mipangg.querymarket.domain.product.dto.ProductDetailResponse;
 import io.mipangg.querymarket.domain.product.dto.ProductListRequest;
@@ -155,17 +157,20 @@ class ProductServiceTests {
     @DisplayName("전체 상품 조회 시 가격순으로 정렬할 수 있다")
     void getProductsSuccessTest() {
 
-        ProductListRequest req = new ProductListRequest(0, 10, "price", null);
-
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("price").ascending());
+        ProductListRequest req = new ProductListRequest(null, 0, 10, "price", null);
 
         List<ProductSummaryResponse> content = genProductSummaryResponseSortByPrice();
+
         Page<ProductSummaryResponse> page =
-                new PageImpl<>(content, PageRequest.of(1, 10), content.size());
+                new PageImpl<>(content, PageRequest.of(0, 10), content.size());
 
-        when(productRepository.findProducts(req.category(), pageable)).thenReturn(page);
+        when(productRepository.findProducts(
+                isNull(),
+                any(Pageable.class)
+        )).thenReturn(page);
 
-        PageResponse<ProductSummaryResponse> resp = productService.getProducts(req);
+        PageResponse<ProductSummaryResponse> resp =
+                (PageResponse<ProductSummaryResponse>) productService.getProducts(req);
 
         assertThat(resp.getContent()).hasSize(content.size());
         ProductSummaryResponse firstProduct = resp.getContent().getFirst();
@@ -215,8 +220,7 @@ class ProductServiceTests {
     @DisplayName("이름에 키워드가 포함된 상품들을 조회할 수 있다")
     void searchProductsSuccessTest() {
 
-        ProductSearchRequest req = new ProductSearchRequest(null, null, null, "빵");
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        ProductSearchRequest req = new ProductSearchRequest(null, null, null, null, "빵");
 
         List<ProductSummaryResponse> content =
                 List.of(
@@ -227,12 +231,15 @@ class ProductServiceTests {
                                 Category.FOOD
                         )
                 );
-        Page<ProductSummaryResponse> page =
-                new PageImpl<>(content, PageRequest.of(1, 10), content.size());
 
-        when(productRepository.searchProductsByKeyword(req.keyword(), pageable)).thenReturn(page);
+        when(productRepository.searchProductsByKeywordWithCursor(
+                anyString(),
+                isNull(),
+                any(Pageable.class)
+        )).thenReturn(content);
 
-        PageResponse<ProductSummaryResponse> resp = productService.searchProducts(req);
+        CursorPageResponse<ProductSummaryResponse> resp =
+                (CursorPageResponse<ProductSummaryResponse>)productService.searchProducts(req);
 
         assertThat(resp.getContent().getFirst().name()).isEqualTo("단팥빵");
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #13 

## 📝작업 내용
- 상품 목록 조회 시 '최신순' 정렬일 경우 cursor 페이지네이션 적용
- '가격순' / '조회수순' 정렬일 경우 offset 페이지네이션 적용

1. cursor - latest O
2. () - latest O(cursor)
3. cursor - views -> 금지
4. cursor - price -> 금지
5. page - latest -> cursor 자동적용
6. page - views O
7. page - price O
8. () - price O
9. () - views O
10. () - () O views O


## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함